### PR TITLE
Remove linebreak-style due to autocrlf default rule in git configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,6 @@ module.exports = {
     "key-spacing": "error",
     "keyword-spacing": "error",
     "line-comment-position": "off",
-    "linebreak-style": "error",
     "lines-around-comment": "off",
     "max-depth": "off",
     "max-len": ["error", {


### PR DESCRIPTION
В дополнение к коммиту 5c6da31, что бы при установке через npm корректно подтягивались правила